### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Installation
 ------------------------------------------------------------------------------
 
 ```
-ember install ember-cli-launch-darkly
+ember install @busy-web/ember-cli-launch-darkly
 ```
 
 


### PR DESCRIPTION
The README had install instructions that installed a different, non-scoped, package.

I've updated the instructions to install `@busy-web/ember-cli-launch-darkly`.